### PR TITLE
used EnsureProportionAtLeast

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -563,9 +563,9 @@ pub type TechnicalCouncilInstance = pallet_collective::Instance1;
 pub type TreasuryCouncilInstance = pallet_collective::Instance2;
 
 pub type EnsureTwoThirdsTechnicalCouncil = EnsureProportionMoreThan<AccountId, TechnicalCouncilInstance, 2, 3>;
-pub type EnsureAllTechnicalCouncil = EnsureProportionMoreThan<AccountId, TechnicalCouncilInstance, 1, 1>; // Adding members everyone must agree
+pub type EnsureAllTechnicalCouncil = EnsureProportionAtLeast<AccountId, TechnicalCouncilInstance, 1, 1>; // Adding members everyone must agree
 pub type EnsureTwoThirdsTreasuryCouncil = EnsureProportionMoreThan<AccountId, TreasuryCouncilInstance, 2, 3>;
-pub type EnsureAllTreasuryCouncil = EnsureProportionMoreThan<AccountId, TreasuryCouncilInstance, 1, 1>; // Adding members everyone must agree
+pub type EnsureAllTreasuryCouncil = EnsureProportionAtLeast<AccountId, TreasuryCouncilInstance, 1, 1>; // Adding members everyone must agree
 
 parameter_types! {
     // pub const TecnicalCouncilMotionDuration: BlockNumber = 5 * DAYS;


### PR DESCRIPTION
Reference to issue #25 

Used `EnsureProportionAtLeast` instead of `EnsureProportionMoreThan`. it is because `EnsureProportionMoreThan` is satisfied if the number of approvals is strictly greater than a specified fraction. While `EnsureProportionAtLeast` is satisfied if the number of approvals is at least equal to a specified fraction. It would require at least the full (100%) of the council members to approve an action.