### PR TITLE
Naming Convention for Collective Pallet

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -26,7 +26,7 @@
 mod xcm_config;
 
 // Substrate and Polkadot dependencies
-use crate::{ Timestamp,};
+use crate::Timestamp;
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
@@ -72,7 +72,7 @@ use super::{
 	System, WeightToFee, XcmpQueue, AVERAGE_ON_INITIALIZE_RATIO, EXISTENTIAL_DEPOSIT, DAYS, HOURS, MINUTES,
 	MAXIMUM_BLOCK_WEIGHT, MICRO_UNIT, NORMAL_DISPATCH_RATIO, SLOT_DURATION, VERSION,
 	// Governance
-	TechnicalCouncil, TreasuryCouncil,
+	TechnicalCommittee, TreasuryCouncil,
 };
 use xcm_config::{RelayLocation, XcmOriginToTransactDispatchOrigin};
 
@@ -563,7 +563,7 @@ pub type EnsureAllTreasuryCouncil = EnsureProportionAtLeast<AccountId, TreasuryC
 
 parameter_types! {
     // pub const TecnicalCouncilMotionDuration: BlockNumber = 5 * DAYS;
-	pub const TecnicalCouncilMotionDuration: BlockNumber = 5 * MINUTES; // For testing purpose only
+	pub const TecnicalCouncilMotionDuration: BlockNumber = 1 * MINUTES; // For testing purpose only
     pub const TecnicalCouncilMaxProposals: u32 = 100;
     pub const TecnicalCouncilMaxMembers: u32 = 100;
 	pub TechnicalMaxProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
@@ -593,15 +593,15 @@ impl pallet_membership::Config<TechnicalCouncilInstance> for Runtime {
 	type SwapOrigin = EnsureAllTechnicalCouncil;
 	type ResetOrigin = EnsureAllTechnicalCouncil;
 	type PrimeOrigin = EnsureAllTechnicalCouncil;
-	type MembershipInitialized = TechnicalCouncil;
-	type MembershipChanged = TechnicalCouncil;
+	type MembershipInitialized = TechnicalCommittee;
+	type MembershipChanged = TechnicalCommittee;
 	type MaxMembers = TechnicalMembershipMaxMembers;
 	type WeightInfo = pallet_membership::weights::SubstrateWeight<Runtime>;
 }
 
 parameter_types! {
     // pub const TreasuryCouncilMotionDuration: BlockNumber = 5 * DAYS;
-	pub const TreasuryCouncilMotionDuration: BlockNumber = 5 * MINUTES; // For testing purpose only
+	pub const TreasuryCouncilMotionDuration: BlockNumber = 1 * MINUTES; // For testing purpose only
     pub const TreasuryCouncilMaxProposals: u32 = 100;
     pub const TreasuryCouncilMaxMembers: u32 = 100;
 	pub TreasuryMaxProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -4,8 +4,8 @@ use crate::{
 	AccountId, BalancesConfig, CollatorSelectionConfig, ParachainInfoConfig, PolkadotXcmConfig,
 	RuntimeGenesisConfig, SessionConfig, SessionKeys, EXISTENTIAL_DEPOSIT,
 	// Membership - Technical council (sudo replacement) and Treasury council
-	TechnicalCouncilConfig, TechnicalCouncilMembershipConfig,configs::TechnicalMembershipMaxMembers,
-	TreasuryCouncilConfig, TreasuryCouncilMembershipConfig,configs::TreasuryMembershipMaxMembers,
+	TechnicalCommitteeMembershipConfig,configs::TechnicalMembershipMaxMembers,
+	TreasuryCouncilMembershipConfig,configs::TreasuryMembershipMaxMembers,
 };
 use alloc::{vec, vec::Vec};
 use parachains_common::{genesis_config_helpers::*, AuraId};
@@ -27,15 +27,15 @@ pub fn template_session_keys(keys: AuraId) -> SessionKeys {
 fn testnet_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	endowed_accounts: Vec<AccountId>,
-	technical_council_members: Vec<AccountId>,
+	technical_committee_members: Vec<AccountId>,
 	treasury_council_members: Vec<AccountId>,
 	id: ParaId,
 ) -> Value {
 
 	// Technical council
-	let technical_council_members: Vec<AccountId32> = technical_council_members.clone();
-    let bounded_technical_council_members = BoundedVec::<_, TechnicalMembershipMaxMembers>::try_from(
-        technical_council_members.clone(),
+	let technical_committee_members: Vec<AccountId32> = technical_committee_members.clone();
+    let bounded_technical_committee_members = BoundedVec::<_, TechnicalMembershipMaxMembers>::try_from(
+        technical_committee_members.clone(),
     ).expect("Technical council members exceed the allowed limit");
 
 	// Treasury council
@@ -75,8 +75,8 @@ fn testnet_genesis(
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
 			..Default::default()
 		},
-		technical_council_membership: TechnicalCouncilMembershipConfig {
-            members: bounded_technical_council_members,
+		technical_committee_membership: TechnicalCommitteeMembershipConfig {
+            members: bounded_technical_committee_members,
             phantom: Default::default(),
         },
 		treasury_council_membership: TreasuryCouncilMembershipConfig {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -323,9 +323,9 @@ mod runtime {
 	#[runtime::pallet_index(44)]
 	pub type Treasury = pallet_treasury;
 	#[runtime::pallet_index(45)]
-	pub type TechnicalCouncil = pallet_collective::Pallet<Runtime, Instance1>;
+	pub type TechnicalCommittee = pallet_collective::Pallet<Runtime, Instance1>;
 	#[runtime::pallet_index(46)]
-	pub type TechnicalCouncilMembership = pallet_membership::Pallet<Runtime, Instance1>;
+	pub type TechnicalCommitteeMembership = pallet_membership::Pallet<Runtime, Instance1>;
 	#[runtime::pallet_index(47)]
 	pub type TreasuryCouncil = pallet_collective::Pallet<Runtime, Instance2>;
 	#[runtime::pallet_index(48)]


### PR DESCRIPTION
### What?

- Change name of technical collective pallet

### Why?

- [Polkadot JS App](https://polkadot.js.org/apps) cannot read other naming convention for its existing collectives by default.
- Considered valid name for technical collective is `TechnicalCommittee`. 
- Naming it randomly somehow leads to `BadOrigin` error which cannot recognize the members when an extrinsic that has `ensure_root()` is called.
- This allows you to have UI control in [Polkadot JS App](https://polkadot.js.org/apps) technical committee

### Screeenshot

- Using `TechnicalCommittee` naming convention
![image](https://github.com/user-attachments/assets/f2906488-d73d-4a8a-aa66-165896f0b619)

- Naming it to undefined name by dapps
![image](https://github.com/user-attachments/assets/828cb524-2349-4430-925f-350515a0c664)

- Technical Committee UI Control
![image](https://github.com/user-attachments/assets/98afa1ce-e38d-468a-8d4b-5b27134812b4)

