### PR TITLE
test: added unit tests for register_candidate function

### DIFF
--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -318,6 +318,9 @@ pub mod pallet {
 		pub fn bond_candidate(origin: OriginFor<T>, new_bond: BalanceOf<T>,) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
+			// Check if the candidate is registered.
+			ensure!(ProposedCandidates::<T>::get().iter().any(|c| c.who == who), Error::<T>::ProposedCandidateNotFound); 
+
 			// When we set the new bond to zero we assume that the candidate is leaving
 			if new_bond == Zero::zero() {
 				ensure!(!WaitingCandidates::<T>::get().contains(&who), Error::<T>::WaitingCandidateMember);

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -318,9 +318,6 @@ pub mod pallet {
 		pub fn bond_candidate(origin: OriginFor<T>, new_bond: BalanceOf<T>,) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			// Check if the candidate is registered.
-			ensure!(ProposedCandidates::<T>::get().iter().any(|c| c.who == who), Error::<T>::ProposedCandidateNotFound); 
-
 			// When we set the new bond to zero we assume that the candidate is leaving
 			if new_bond == Zero::zero() {
 				ensure!(!WaitingCandidates::<T>::get().contains(&who), Error::<T>::WaitingCandidateMember);


### PR DESCRIPTION
In this pull request, I have added several possible scenarios to test the register_candidate function. Below is the list of tests that I have included:

- `test_pallet_xode_staking_register_candidate_works`: Tests the successful registration of a candidate.
- `test_pallet_xode_staking_register_candidate_no_existing_candidates`: Tests candidate registration when there are no existing candidates in the system.
- `test_pallet_xode_staking_register_candidate_already_exists_should_error`: Ensures the function throws an error when trying to register a candidate that already exists.
- `test_pallet_xode_staking_register_candidate_max_exceeded_should_error`: Verifies that the function throws an error when the maximum number of candidates has been exceeded.
- `test_pallet_xode_staking_register_candidate_invalid_account_should_error`: Checks that the function throws an error when the candidate is signed by an invalid account.
- `test_pallet_xode_staking_register_candidate_default_values`: Verifies that a newly registered candidate has the correct default values.

These tests cover a wide range of scenarios to ensure the functionality of the register_candidate function works as expected in different situations.

Additionally, I attempted to retrieve the last dispatched events for validation in the tests, but it doesn't seem to be working as expected. It is crucial to capture the last dispatched events in order to ensure that the test works correctly. The `System::assert_last_event` function is used to check that the expected event, such as `ProposedCandidateAdded`, is emitted.

Anyways, I will conduct further research or attempt additional tests to ensure that the `assert_last_event` function works as intended and to resolve any issues with capturing dispatched events.

Thanks!