### PR TITLE
fix: check if the candidate is registered in the bond_candidate function

### DIFF
--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -318,6 +318,9 @@ pub mod pallet {
 		pub fn bond_candidate(origin: OriginFor<T>, new_bond: BalanceOf<T>,) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
+			// Check if the candidate is registered.
+			ensure!(ProposedCandidates::<T>::get().iter().any(|c| c.who == who), Error::<T>::ProposedCandidateNotFound); 
+
 			// When we set the new bond to zero we assume that the candidate is leaving
 			if new_bond == Zero::zero() {
 				ensure!(!WaitingCandidates::<T>::get().contains(&who), Error::<T>::WaitingCandidateMember);

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -318,9 +318,6 @@ pub mod pallet {
 		pub fn bond_candidate(origin: OriginFor<T>, new_bond: BalanceOf<T>,) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			// Check if the candidate is registered.
-			ensure!(ProposedCandidates::<T>::get().iter().any(|c| c.who == who), Error::<T>::ProposedCandidateNotFound); 
-
 			// When we set the new bond to zero we assume that the candidate is leaving
 			if new_bond == Zero::zero() {
 				ensure!(!WaitingCandidates::<T>::get().contains(&who), Error::<T>::WaitingCandidateMember);


### PR DESCRIPTION
In this case, we are checking whether the given candidate (who) exists in the list of proposed candidates.
A candidate must be registered in the system before they can be bonded.

This behavior is enforced based on the documentation: [Xode Staking Process](https://docs.google.com/spreadsheets/d/1xSMzUbkV7sl1g-G5n7-inF9vypxb5ulMLUGyh6weaX0/edit?fbclid=IwZXh0bgNhZW0CMTEAAR3ziAIqFe0-B2oi4yAUnB9iaXFwhZd-J3-10k0C9xxWDnvvqR0o78gMIII_aem_F1GxAqAflRISK0-2CK31JA&gid=0#gid=0)

Thanks!