### PR TITLE
XCM Configuration Update

### DIFF
--- a/runtime/src/configs/xcm_config.rs
+++ b/runtime/src/configs/xcm_config.rs
@@ -23,8 +23,8 @@ use xcm_builder::{
 	FungiblesAdapter, LocalMint
 };
 use xcm_executor::{traits::{MatchesFungibles, Error as MatchError}, XcmExecutor};
-use sp_runtime::print;
-use alloc::format;
+// use sp_runtime::print;
+// use alloc::format;
 
 parameter_types! {
 	pub const RelayLocation: Location = Location::parent();

--- a/zombienet/zombienet-local.toml
+++ b/zombienet/zombienet-local.toml
@@ -1,33 +1,53 @@
-
 [settings]
-timeout = 1000
-node_verifier = "None"
+timeout = 2000
 
 [relaychain]
 default_command = "./bin/polkadot"
-default_args = [ "-l=parachain=debug,xcm=trace" ]
+default_args = ["-lparachain=debug", "-lxcm=trace", "-lruntime=debug"]
 chain = "rococo-local"
 
   [[relaychain.nodes]]
   name = "alice"
   validator = true
-  ws_port = 9944
 
   [[relaychain.nodes]]
   name = "bob"
   validator = true
-  ws_port = 9955
+
+  [[relaychain.nodes]]
+  name = "charlie"
+  validator = true
+
+  [[relaychain.nodes]]
+  name = "dave"
+  validator = true
+
+  [[relaychain.nodes]]
+  name = "eve"
+  validator = true
+
+  [[relaychain.nodes]]
+  name = "ferdie"
+  validator = true
 
 [[parachains]]
 id = 1000
 cumulus_based = true
+add_to_genesis = true
 
   [[parachains.collators]]
-  name = "charlie"
-  command = "../target/release/xode-node"
+  name = "assethub-collator"
+  command = "./bin/polkadot-parachain"
+  args = ["-lxcmp=trace", "-lxcm=trace", "-lruntime=debug"]
   ws_port = 9988
 
+[[parachains]]
+id = 4607
+cumulus_based = true
+add_to_genesis = true
+
   [[parachains.collators]]
-  name = "dave"
+  name = "xode-collator"
   command = "../target/release/xode-node"
+  args = ["-lxcmp=trace", "-lxcm=trace", "-lruntime=debug"]
   ws_port = 9999


### PR DESCRIPTION
This PR introduces enhancements to the XCM configuration in preparation for cross-chain fungible asset transfer testing. Key updates include:

- **Custom Asset Matcher (`MatchesFungibles`)**
  - Maps native relay chain assets (e.g., DOT) to a local asset ID.
  - Includes logic to support assets from AssetHub (Parachain 1000) and other parachains (e.g., 4607) by matching `Parachain`, `PalletInstance`, and `GeneralIndex` in the XCM asset location.
  - This logic is included for testing purposes and will be validated on the PASEO testnet.

- **Support for `reserve_transfer_assets`**
  - Enables asset recognition and transfers using XCM’s `reserve_transfer_assets`.

- **Improved Asset Location Decoding**
  - Refactored pattern matching for fungible assets to support more structured and scalable asset location handling.

- **Zombienet Configuration Update**
  - Updated `zombienet.toml` to allow running two parachains locally:
    - One **Polkadot-compatible parachain**
    - One **local parachain** (Xode)
  - This setup is for general development and local runtime testing.

This update lays the foundation for full cross-chain asset transfer capabilities and improves support for future integrations across multiple parachains.
