### PR TITLE
Fixes the NextIndex issue in RPC calls.

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,6 +1,7 @@
 //! Substrate Parachain Node Template CLI
 
 #![warn(missing_docs)]
+use sp_core::crypto::{Ss58AddressFormat, set_default_ss58_version};
 
 mod chain_spec;
 mod cli;
@@ -9,5 +10,6 @@ mod rpc;
 mod service;
 
 fn main() -> sc_cli::Result<()> {
+	set_default_ss58_version(Ss58AddressFormat::custom(280));
 	command::run()
 }


### PR DESCRIPTION
Added code in main.rs to enforce the use of SS58 address prefix 280 as the default for the node.